### PR TITLE
automated release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,27 @@
+name: release
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.20.0'
+          cache: true
+      - run: go mod tidy
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 demo.tape
 ssl-checker
 ssl-checker.log
+dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,27 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This is `ssl-checker`, a Go CLI program that I created as a playground project. 
     <img width="700" src="demo.gif" />
 </p>
 
+## Installation
+
+```
+$ go install github.com/fabio42/ssl-checker@latest
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
This PR adds release automation

To release new version just push a new semver tag (with `v` prefix)
This will start github actions workflow that will generate binaries, compile changelog and release them to [github releases](https://github.com/fabio42/ssl-checker/releases)
